### PR TITLE
fix: use proper tar (not busybox)

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -49,8 +49,8 @@ jobs:
         path: build/docs/html/
         if-no-files-found: error
     - run: |
-        apk add bash
-        # FIXME tracking https://github.com/actions/upload-pages-artifact/pull/14
+        apk add tar bash
+        # FIXME bash not really required: see https://github.com/actions/upload-pages-artifact/pull/14
     - uses: actions/upload-pages-artifact@v1
       if: github.ref == 'refs/heads/master'
       with:


### PR DESCRIPTION
`actions/upload-pages-artifact` uses options of `tar` that are not available with the `busybox` inside alpine.