### PR TITLE
feat(PID): extensions for IRT data model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(ROOT REQUIRED COMPONENTS Core RIO Tree)
 include(${ROOT_USE_FILE})
 
-PODIO_GENERATE_DATAMODEL(eicd eic_data.yaml headers sources OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR})
+PODIO_GENERATE_DATAMODEL(eicd eic_data.yaml headers sources
+  UPSTREAM_EDM edm4hep:${EDM4HEP_DATA_DIR}/edm4hep.yaml
+  OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
+  )
 
 add_library(eicd SHARED
   ${sources}

--- a/eic_data.yaml
+++ b/eic_data.yaml
@@ -269,13 +269,21 @@ datatypes:
         "
 
 
-  eic::ReconstructedParticleLocation:
-    Description: "EIC Reconstructed Particle Location"
-    Author: "W. Armstrong, S. Joosten"
+  eic::ChargedParticleLocation:
+    Description: "EIC Particle Location"
+    Author: "A. Kiselev, C. Dilks"
     Members:
-      - eic::Index        ID                // Unique particle index
+      - eic::Index        ID                // Unique index
       - eic::VectorXYZ    p                 // Momentum vector [GeV]
-      - eic::VectorXYZ    v                 // Vertex [mm]
+      - eic::VectorXYZ    v                 // 3D location [mm]
+      - float             t                 // Time [ns]
+
+  eic::ChargedParticleTrajectory:
+    Description: "EIC Charged Particle Trajectory"
+    Author: "A. Kiselev, C. Dilks"
+    Members:
+      - eic::Index        ID                // Unique index
+      - std::array<eic::Index, 10> location // (Up to 10, let's be generous) particle locations, ordered in time
 
       - eic::Index        recID             // Index of the associated ReconstructedParticle particle, if any
 
@@ -286,7 +294,7 @@ datatypes:
       - eic::Index        ID                // Unique entry ID
       - int32_t           pdg               // PDG code
       - int16_t           npe               // Overall p.e. count associated with this hypothesis for a given track
-      - float             weight            // The mass of the particle in [GeV]
+      - float             weight            // The weight associated with this hypothesis (the higher the more probable)
 
   eic::CherenkovPID:
     Description: "Cherenkov detector PID"

--- a/eic_data.yaml
+++ b/eic_data.yaml
@@ -201,7 +201,7 @@ components:
       - float             pathlengthError // Error on the pathlenght
  
   ## PID hypothesis from Cherenkov detectors
-  eic::CherenkovPdgHypothesis:
+  eicd::CherenkovPdgHypothesis:
     Members:
       - char              radiator          // Radiator number (0/1/..) in a sequence of the IRTAlgorithm configuration file
       - int32_t           pdg               // PDG code
@@ -209,7 +209,7 @@ components:
       - float             weight            // The weight associated with this hypothesis (the higher the more probable)
 
   ## Cherenkov angle measurement for a given radiator
-  eic::CherenkovThetaAngleMeasurement:
+  eicd::CherenkovThetaAngleMeasurement:
     Members:
       - char              radiator          // Radiator number (0/1/..) in a sequence of the IRTAlgorithm configuration file
       - float             npe               // Overall p.e. count associated with this estimate
@@ -285,12 +285,12 @@ datatypes:
         bool isCompound() const {return particles_size() > 0;}\n
         "
 
-  eic::CherenkovParticleID:
+  eicd::CherenkovParticleID:
     Description: "Cherenkov detector PID"
     Author: "A. Kiselev, C. Dilks"
     VectorMembers:
-      - eic::CherenkovPdgHypothesis options        // Evaluated PDG hypotheses, typically (e/pi/K/p)
-      - eic::CherenkovThetaAngleMeasurement angles // Evaluated Cherenkov angles for different radiators
+      - eicd::CherenkovPdgHypothesis options        // Evaluated PDG hypotheses, typically (e/pi/K/p)
+      - eicd::CherenkovThetaAngleMeasurement angles // Evaluated Cherenkov angles for different radiators
     OneToOneRelations:
       ## @TODO: should it be one-to-one?
       - eicd::ReconstructedParticle associatedParticle // associated reconstructed particle

--- a/eic_data.yaml
+++ b/eic_data.yaml
@@ -217,6 +217,13 @@ components:
       - float             npe               // Overall p.e. count associated with this hypothesis for a given track
       - float             weight            // The weight associated with this hypothesis (the higher the more probable)
 
+  ## Cherenkov angle measurement for a given radiator
+  eic::CherenkovThetaAngleMeasurement:
+    Members:
+      - char              radiator          // Radiator number (0/1/..) in a sequence of the IRTAlgorithm configuration file
+      - float             npe               // Overall p.e. count associated with this estimate
+      - float             theta             // Cherenkov theta angle
+
 datatypes:
 
   ## ==========================================================================
@@ -290,10 +297,11 @@ datatypes:
     Description: "Cherenkov detector PID"
     Author: "A. Kiselev, C. Dilks"
     Members:
-      - eic::Index        ID                // Unique entry ID
-      - eic::Index        recID             // Index of the associated ReconstructedParticle particle, if any
+      - eic::Index        ID                       // Unique entry ID
+      - eic::Index        recID                    // Index of the associated ReconstructedParticle particle, if any
     VectorMembers:
-      - eic::CherenkovPdgHypothesis options // Evaluated PDG hypotheses, typically (e/pi/K/p)
+      - eic::CherenkovPdgHypothesis options        // Evaluated PDG hypotheses, typically (e/pi/K/p)
+      - eic::CherenkovThetaAngleMeasurement angles // Evaluated Cherenkov angles for different radiators
 
   ## ==========================================================================
   ## Calorimetry

--- a/eic_data.yaml
+++ b/eic_data.yaml
@@ -291,7 +291,6 @@ datatypes:
     Members:
       - eic::Index        ID                // Unique entry ID
       - eic::Index        recID             // Index of the associated ReconstructedParticle particle, if any
-
     VectorMembers:
       - eic::CherenkovPdgHypothesis options // Evaluated PDG hypotheses, typically (e/pi/K/p)
 

--- a/eic_data.yaml
+++ b/eic_data.yaml
@@ -268,6 +268,24 @@ datatypes:
         bool isCompound() const {return particles_size() > 0;}\n
         "
 
+      - eic::Index        pidID             // Index of the associated Cherenkov PID, if any
+
+
+  eic::CherenkovMassHypothesis:
+    Description: "Cherenkov detector PID mass hypothesis"
+    Author: "A. Kiselev, C. Dilks"
+    Members:
+      - eic::Index        ID                // Unique entry ID
+      - int16_t           npe               // Overall p.e. count associated with this hypothesis for a given track
+      - float             weight            // The mass of the particle in [GeV]
+
+  eic::CherenkovPID:
+    Description: "Cherenkov detector PID"
+    Author: "A. Kiselev, C. Dilks"
+    Members:
+      - eic::Index        ID                // Unique entry ID
+      - std::array<eic::Index, 4> hypotheses// (Up to 4) mass hypotheses (e/pi/K/p)
+
   ## ==========================================================================
   ## Calorimetry
   ## ==========================================================================

--- a/eic_data.yaml
+++ b/eic_data.yaml
@@ -280,7 +280,7 @@ datatypes:
       - eicd::CherenkovThetaAngleMeasurement angles // Evaluated Cherenkov angles for different radiators
     OneToOneRelations:
       ## @TODO: should it be one-to-one?
-      - eicd::ReconstructedParticle associatedParticle // associated reconstructed particle
+      - edm4hep::MCParticle associatedParticle // associated reconstructed particle
 
   ## ==========================================================================
   ## Calorimetry

--- a/eic_data.yaml
+++ b/eic_data.yaml
@@ -224,6 +224,7 @@ components:
       - float             npe               // Overall p.e. count associated with this estimate
       - float             theta             // Cherenkov theta angle
       - float             rindex            // Average refractive index for this collection of photons
+      - float             wavelength        // Average wavelength for this collection of photons
 
 datatypes:
 

--- a/eic_data.yaml
+++ b/eic_data.yaml
@@ -268,14 +268,23 @@ datatypes:
         bool isCompound() const {return particles_size() > 0;}\n
         "
 
-      - eic::Index        pidID             // Index of the associated Cherenkov PID, if any
 
+  eic::ReconstructedParticleLocation:
+    Description: "EIC Reconstructed Particle Location"
+    Author: "W. Armstrong, S. Joosten"
+    Members:
+      - eic::Index        ID                // Unique particle index
+      - eic::VectorXYZ    p                 // Momentum vector [GeV]
+      - eic::VectorXYZ    v                 // Vertex [mm]
+
+      - eic::Index        recID             // Index of the associated ReconstructedParticle particle, if any
 
   eic::CherenkovMassHypothesis:
     Description: "Cherenkov detector PID mass hypothesis"
     Author: "A. Kiselev, C. Dilks"
     Members:
       - eic::Index        ID                // Unique entry ID
+      - int32_t           pdg               // PDG code
       - int16_t           npe               // Overall p.e. count associated with this hypothesis for a given track
       - float             weight            // The mass of the particle in [GeV]
 
@@ -284,7 +293,9 @@ datatypes:
     Author: "A. Kiselev, C. Dilks"
     Members:
       - eic::Index        ID                // Unique entry ID
-      - std::array<eic::Index, 4> hypotheses// (Up to 4) mass hypotheses (e/pi/K/p)
+      - std::array<eic::Index, 4> hypothesis// (Up to 4) mass hypotheses (e/pi/K/p)
+
+      - eic::Index        recID             // Index of the associated ReconstructedParticle particle, if any
 
   ## ==========================================================================
   ## Calorimetry

--- a/eic_data.yaml
+++ b/eic_data.yaml
@@ -200,6 +200,22 @@ components:
       - float             pathlength      // Pathlength from the origin to this point
       - float             pathlengthError // Error on the pathlenght
  
+  ## A point along a trajectory
+  eic::TrajectoryPoint:
+    Members:
+      - eic::VectorXYZ    position      // Position of the trajectory point [mm]
+      - eic::VectorXYZ    p             // 3-momentum at the point [GeV]
+      - eic::Direction    direction     // (theta, phi) direction of track at the surface [mrad]
+      - float             momentum      // magnitude of 3-momentum [GeV]
+      - float             pathlength    // Pathlength from the origin to this point
+
+  ## PID hypothesis from Cherenkov detectors
+  eic::CherenkovPdgHypothesis:
+    Members:
+      - int32_t           pdg               // PDG code
+      - int16_t           npe               // Overall p.e. count associated with this hypothesis for a given track
+      - float             weight            // The weight associated with this hypothesis (the higher the more probable)
+
 datatypes:
 
   ## ==========================================================================
@@ -269,41 +285,15 @@ datatypes:
         "
 
 
-  eic::ChargedParticleLocation:
-    Description: "EIC Particle Location"
-    Author: "A. Kiselev, C. Dilks"
-    Members:
-      - eic::Index        ID                // Unique index
-      - eic::VectorXYZ    p                 // Momentum vector [GeV]
-      - eic::VectorXYZ    v                 // 3D location [mm]
-      - float             t                 // Time [ns]
-
-  eic::ChargedParticleTrajectory:
-    Description: "EIC Charged Particle Trajectory"
-    Author: "A. Kiselev, C. Dilks"
-    Members:
-      - eic::Index        ID                // Unique index
-      - std::array<eic::Index, 10> location // (Up to 10, let's be generous) particle locations, ordered in time
-
-      - eic::Index        recID             // Index of the associated ReconstructedParticle particle, if any
-
-  eic::CherenkovMassHypothesis:
-    Description: "Cherenkov detector PID mass hypothesis"
-    Author: "A. Kiselev, C. Dilks"
-    Members:
-      - eic::Index        ID                // Unique entry ID
-      - int32_t           pdg               // PDG code
-      - int16_t           npe               // Overall p.e. count associated with this hypothesis for a given track
-      - float             weight            // The weight associated with this hypothesis (the higher the more probable)
-
-  eic::CherenkovPID:
+  eic::CherenkovParticleID:
     Description: "Cherenkov detector PID"
     Author: "A. Kiselev, C. Dilks"
     Members:
       - eic::Index        ID                // Unique entry ID
-      - std::array<eic::Index, 4> hypothesis// (Up to 4) mass hypotheses (e/pi/K/p)
-
       - eic::Index        recID             // Index of the associated ReconstructedParticle particle, if any
+
+    VectorMembers:
+      - eic::CherenkovPdgHypothesis options // Evaluated PDG hypotheses, typically (e/pi/K/p)
 
   ## ==========================================================================
   ## Calorimetry

--- a/eic_data.yaml
+++ b/eic_data.yaml
@@ -212,8 +212,9 @@ components:
   ## PID hypothesis from Cherenkov detectors
   eic::CherenkovPdgHypothesis:
     Members:
+      - char              radiator          // Radiator number (0/1/..) in a sequence of the IRTAlgorithm configuration file
       - int32_t           pdg               // PDG code
-      - int16_t           npe               // Overall p.e. count associated with this hypothesis for a given track
+      - float             npe               // Overall p.e. count associated with this hypothesis for a given track
       - float             weight            // The weight associated with this hypothesis (the higher the more probable)
 
 datatypes:

--- a/eic_data.yaml
+++ b/eic_data.yaml
@@ -223,6 +223,7 @@ components:
       - char              radiator          // Radiator number (0/1/..) in a sequence of the IRTAlgorithm configuration file
       - float             npe               // Overall p.e. count associated with this estimate
       - float             theta             // Cherenkov theta angle
+      - float             rindex            // Average refractive index for this collection of photons
 
 datatypes:
 

--- a/eic_data.yaml
+++ b/eic_data.yaml
@@ -200,15 +200,6 @@ components:
       - float             pathlength      // Pathlength from the origin to this point
       - float             pathlengthError // Error on the pathlenght
  
-  ## A point along a trajectory
-  eic::TrajectoryPoint:
-    Members:
-      - eic::VectorXYZ    position      // Position of the trajectory point [mm]
-      - eic::VectorXYZ    p             // 3-momentum at the point [GeV]
-      - eic::Direction    direction     // (theta, phi) direction of track at the surface [mrad]
-      - float             momentum      // magnitude of 3-momentum [GeV]
-      - float             pathlength    // Pathlength from the origin to this point
-
   ## PID hypothesis from Cherenkov detectors
   eic::CherenkovPdgHypothesis:
     Members:
@@ -294,16 +285,15 @@ datatypes:
         bool isCompound() const {return particles_size() > 0;}\n
         "
 
-
   eic::CherenkovParticleID:
     Description: "Cherenkov detector PID"
     Author: "A. Kiselev, C. Dilks"
-    Members:
-      - eic::Index        ID                       // Unique entry ID
-      - eic::Index        recID                    // Index of the associated ReconstructedParticle particle, if any
     VectorMembers:
       - eic::CherenkovPdgHypothesis options        // Evaluated PDG hypotheses, typically (e/pi/K/p)
       - eic::CherenkovThetaAngleMeasurement angles // Evaluated Cherenkov angles for different radiators
+    OneToOneRelations:
+      ## @TODO: should it be one-to-one?
+      - eicd::ReconstructedParticle associatedParticle // associated reconstructed particle
 
   ## ==========================================================================
   ## Calorimetry


### PR DESCRIPTION
Probably shouldn't be merged, but this branch supports ongoing IRT development for the dRICH. We should check if our needs are supported in `EDM4hep`, and if not, what additions we want.

Moved from https://eicweb.phy.anl.gov/EIC/eicd/-/merge_requests/70