### PR TITLE
fix: add EDM4hep include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,7 @@ find_package(podio 0.15 REQUIRED)
 include_directories(${podio_INCLUDE_DIR})
 
 find_package(EDM4HEP 0.4.1 REQUIRED)
-include_directories(${EDM4HEP_INCLUDE_DIR})
 
-#include(cmake/root.cmake)
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(ROOT 6 REQUIRED COMPONENTS Core RIO Tree)
@@ -36,6 +34,9 @@ PODIO_GENERATE_DATAMODEL(eicd eic_data.yaml headers sources
 PODIO_ADD_DATAMODEL_CORE_LIB(eicd "${headers}" "${sources}"
   OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}
 )
+# The target for the data model library is defined in podio/cmake/podioMacros.cmake
+# Any changes to that target name upstream may require changes to the target used here 
+target_include_directories(eicd PUBLIC ${EDM4HEP_INCLUDE_DIR})
 
 PODIO_ADD_ROOT_IO_DICT(eicdDict eicd "${headers}" src/selection.xml
   OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(podio 0.15 REQUIRED)
 include_directories(${podio_INCLUDE_DIR})
 
 find_package(EDM4HEP 0.4.1 REQUIRED)
+include_directories(${EDM4HEP_INCLUDE_DIR})
 
 #include(cmake/root.cmake)
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})


### PR DESCRIPTION
This addresses an issue when EDM4hep is installed in a dedicated prefix and the include directory does not end up in the compilation include line by virtue of other includes (as is the case when everything is in /usr/local).

### Briefly, what does this PR introduce?
New include directory in the top level CMakeLists.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, in that it makes the default compilation succeed on some systems where it previously didn't.